### PR TITLE
Modify bin/amigo.js to allow more than 1000 parameters.  Set it to 10…

### DIFF
--- a/bin/amigo.js
+++ b/bin/amigo.js
@@ -359,7 +359,7 @@ var app = express();
 app.use(cors());
 // Add POST via JSON.
 app.use(body_parser.json());
-app.use(body_parser.urlencoded({'extended': true}));
+app.use(body_parser.urlencoded({'extended': true, parameterLimit: 100000, limit: '50mb' }));
 
 ///
 /// User pages.


### PR DESCRIPTION
…0000 and 50mb.

This fixes an issue in planteome/amigo where the API fails if the request contains more than 1000 parameters.