### PR TITLE
Remove neo from ontology list as it is already imported by go-lego

### DIFF
--- a/conf/examples/amigo.yaml.noctua
+++ b/conf/examples/amigo.yaml.noctua
@@ -154,7 +154,6 @@ GOLR_ONTOLOGY_LIST:
     - http://purl.obolibrary.org/obo/uberon/basic.owl
     - http://purl.obolibrary.org/obo/wbbt.owl
     - http://purl.obolibrary.org/obo/go/extensions/go-modules-annotations.owl
-    - http://build.berkeleybop.org/job/build-noctua-entity-ontology/lastSuccessfulBuild/artifact/neo.obo
     - http://purl.obolibrary.org/obo/go/extensions/go-taxon-subsets.owl
 GOLR_PANTHER_FILE_PATH:
   comment: The location of the cleaned PANTHER file for the proper loading into GOlr.


### PR DESCRIPTION
go-lego.owl includes neo (using the official PURL) so there is no need for a duplicate load