### PR TITLE
Update ann-config.yaml

### DIFF
--- a/metadata/ann-config.yaml
+++ b/metadata/ann-config.yaml
@@ -133,13 +133,26 @@ fields:
     property: []
     searchable: true
   - id: regulates_closure
-    description: "Annotations for this term or its children (over regulates)."
+    description: "Annotations for this term or its children (over regulates, including isa/part-of)."
     display_name: GO class
     type: string
     cardinality: multi
     property: []
   - id: regulates_closure_label
-    description: "Annotations for this term or its children (over regulates)."
+    description: "Annotations for this term or its children (over regulates, including isa/part-of)."
+    display_name: GO class
+    type: string
+    cardinality: multi
+    property: []
+    searchable: true
+  - id: regulates_strict_closure
+    description: "Annotations for this term or its children (over regulates but not part-of)."
+    display_name: GO class
+    type: string
+    cardinality: multi
+    property: []
+  - id: regulates_strict_closure_label
+    description: "Annotations for this term or its children (over regulates not not part-of)."
     display_name: GO class
     type: string
     cardinality: multi


### PR DESCRIPTION
Clarified semantics of regulates closure and adding a proposed new closure for getting 'regulates only'; i.e. following is_a and regulates (and -/+), with at least one regulates hop in there.

We will want to expose this on amigo, and also via APIs, see https://github.com/biolink/biolink-api/issues/138

cc @selewis