### PR TITLE
added monit to golr container and log rotation monit, of amigo logs and golr jetty process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 provision
+.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,10 @@ RUN apt-get -qq update && apt-get -qq -y install \
 	libjson-xs-perl liburi-perl libwww-mechanize-perl \
 	liburi-encode-perl libxml-libxml-perl libxml-xpath-perl \
 	dh-make-perl apache2 openjdk-8-jdk openjdk-8-jre jetty9 \
-        monit psmisc
+        monit psmisc logrotate
+
+RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d \
+    && rm -rf /var/log && mkdir -p /var/log
 
 ## AmiGO weirdness.
 ADD docker/libsql-tokenizer-perl_0.24-2_all.deb /tmp/libsql-tokenizer-perl_0.24-2_all.deb
@@ -133,6 +136,8 @@ ENV GOLR_SOLR_MEMORY=4G
 COPY ./docker/entrypoint.sh /
 COPY ./docker/run-golr.sh /
 RUN chmod +x /entrypoint.sh /run-golr.sh && md5sum ./conf/amigo.yaml > amigo-hash
-COPY ./docker/java /etc/monit/conf-enabled/
+COPY ./docker/java-golr-monit /etc/monit/conf-enabled/java
+COPY ./docker/java-golr-monit /etc/monit/conf-enabled/java
+COPY ./docker/console-capture-golr.xml /etc/jetty9/console-capture.xml
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["tail", "-f", "/dev/null" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,15 +44,17 @@ RUN apt-get -qq update && apt-get -qq -y install \
 	libfreezethaw-perl libgraph-perl libgraphviz-perl \
 	libjson-xs-perl liburi-perl libwww-mechanize-perl \
 	liburi-encode-perl libxml-libxml-perl libxml-xpath-perl \
-	dh-make-perl apache2 openjdk-8-jdk openjdk-8-jre jetty9
+	dh-make-perl apache2 openjdk-8-jdk openjdk-8-jre jetty9 \
+        monit psmisc
 
 ## AmiGO weirdness.
 ADD docker/libsql-tokenizer-perl_0.24-2_all.deb /tmp/libsql-tokenizer-perl_0.24-2_all.deb
 RUN dpkg -i /tmp/libsql-tokenizer-perl_0.24-2_all.deb
 
 ## Node.
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs \
+    && apt-get -qq purge && apt-get -qq clean && rm -rf /var/lib/apt/lists/*
 
 ## Grab the AmiGO/GOlr repo and change context.
 RUN mkdir -p /srv
@@ -68,54 +70,52 @@ USER root
 ###
 
 ## Get apache setup as a generic worker. Installation grouped above.
-RUN a2dismod mpm_event mpm_worker
-RUN a2enmod mpm_prefork
-RUN a2dismod cgid mpm_event mpm_worker
-RUN a2enmod alias mpm_prefork cgi rewrite proxy proxy_http proxy_html macro headers xml2enc
+RUN a2dismod mpm_event mpm_worker \
+    && a2enmod mpm_prefork \
+    && a2dismod cgid mpm_event mpm_worker \
+    && a2enmod alias mpm_prefork cgi rewrite proxy proxy_http proxy_html macro headers xml2enc
 
 ###
 ### GOlr/Jetty.
 ###
 
 ## GOlr/Jetty setup. Installation grouped above.
-RUN cp ./golr/solr/solr.war /var/lib/jetty9/webapps/
-RUN chown jetty /var/lib/jetty9/webapps/solr.war
-RUN chgrp adm /var/lib/jetty9/webapps/solr.war
-RUN cp ./golr/jetty/jetty /etc/default/jetty9
-RUN mkdir -p /srv/solr/data
-RUN mkdir -p /srv/solr/conf
-RUN cp ./golr/solr/conf/schema.xml /srv/solr/conf/schema.xml
-RUN cp ./golr/solr/conf/solrconfig.xml /srv/solr/conf/solrconfig.xml
-RUN chown -R jetty /srv/solr/
-RUN chgrp -R adm /srv/solr/
+RUN cp ./golr/solr/solr.war /var/lib/jetty9/webapps/ \
+    && chown jetty /var/lib/jetty9/webapps/solr.war \
+    && chgrp adm /var/lib/jetty9/webapps/solr.war \
+    && cp ./golr/jetty/jetty /etc/default/jetty9 \
+    && mkdir -p /srv/solr/data \
+    && mkdir -p /srv/solr/conf \
+    && cp ./golr/solr/conf/schema.xml /srv/solr/conf/schema.xml \
+    && cp ./golr/solr/conf/solrconfig.xml /srv/solr/conf/solrconfig.xml \
+    && chown -R jetty /srv/solr/ \
+    && chgrp -R adm /srv/solr/
 
 ## Custom runtime locations for jetty9/solr for the Docker environment.
-RUN mkdir -p /tmp/jetty9
-RUN chown -R jetty /tmp/jetty9
-RUN chgrp -R adm /tmp/jetty9
+RUN mkdir -p /tmp/jetty9 \
+    && chown -R jetty /tmp/jetty9 \
+    && chgrp -R adm /tmp/jetty9
 
 ###
 ### AmiGO.
 ###
 
 ## Final Apache setup.
-RUN cp ./conf/examples/apache2.18_04.localhost_root.conf /etc/apache2/sites-available/001-inline-amigo.conf
-RUN cp /srv/amigo/conf/examples/apache2.ports.conf /etc/apache2/ports.conf
-RUN a2ensite 001-inline-amigo
-
 ## Get AmiGO docker config into place.
-RUN cp ./conf/examples/amigo.yaml.localhost_docker_loader ./conf/amigo.yaml
+RUN cp ./conf/examples/apache2.18_04.localhost_root.conf /etc/apache2/sites-available/001-inline-amigo.conf \
+    && cp /srv/amigo/conf/examples/apache2.ports.conf /etc/apache2/ports.conf \
+    && a2ensite 001-inline-amigo \
+    && cp ./conf/examples/amigo.yaml.localhost_docker_loader ./conf/amigo.yaml
 
 ## AmiGO install.
 USER root:www-data
-RUN npm install
-RUN ./node_modules/.bin/gulp install
+RUN npm install && ./node_modules/.bin/gulp install
 USER root
 
 ## The root environment seems to do something funny with the perl5
 ## execution path; modify tp make sure everybody can get at it.
-RUN sed -i s,config.pl,/srv/amigo/perl/bin/config.pl,g /srv/amigo/perl/bin/*
-RUN sed -i s,config.pl,/srv/amigo/perl/bin/config.pl,g /srv/amigo/perl/lib/AmiGO.pm
+RUN sed -i s,config.pl,/srv/amigo/perl/bin/config.pl,g /srv/amigo/perl/bin/* \
+    && sed -i s,config.pl,/srv/amigo/perl/bin/config.pl,g /srv/amigo/perl/lib/AmiGO.pm
 
 ###
 ### Finally.
@@ -129,7 +129,10 @@ EXPOSE 8080 9999
 #RUN ["chmod", "+x", "/tmp/run-apache-solr.sh"]
 #CMD "/tmp/run-apache-solr.sh"
 
+ENV GOLR_SOLR_MEMORY=4G
 COPY ./docker/entrypoint.sh /
-RUN chmod +x /entrypoint.sh && md5sum ./conf/amigo.yaml > amigo-hash
+COPY ./docker/run-golr.sh /
+RUN chmod +x /entrypoint.sh /run-golr.sh && md5sum ./conf/amigo.yaml > amigo-hash
+COPY ./docker/java /etc/monit/conf-enabled/
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["tail", "-f", "/dev/null" ]

--- a/docker/console-capture-golr.xml
+++ b/docker/console-capture-golr.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="logging" class="org.eclipse.jetty.util.log.Log">
+    <New id="ServerLog" class="java.io.PrintStream">
+      <Arg>
+        <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
+                <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="/var/log/jetty9"/>/yyyy_mm_dd.jetty.log</Arg>
+          <Arg type="boolean"><Property name="jetty.console-capture.append" deprecated="jetty.logging.append" default="false"/></Arg>
+          <Arg type="int"><Property name="jetty.console-capture.retainDays" deprecated="jetty.logging.retainDays" default="30"/></Arg>
+          <Arg>
+            <Call class="java.util.TimeZone" name="getTimeZone">
+              <Arg><Property name="jetty.console-capture.timezone" deprecated="jetty.logging.timezone" default="GMT"/></Arg>
+            </Call>
+          </Arg>
+          <Get id="ServerLogName" name="datedFilename"/>
+        </New>
+      </Arg>
+    </New>
+
+    <Get name="rootLogger">
+      <Call name="info"><Arg>Console stderr/stdout captured to <Ref refid="ServerLogName"/></Arg></Call>
+    </Get>
+    <Call class="java.lang.System" name="setErr"><Arg><Ref refid="ServerLog"/></Arg></Call>
+    <Call class="java.lang.System" name="setOut"><Arg><Ref refid="ServerLog"/></Arg></Call>
+</Configure>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,7 +37,9 @@ if [ $AMIGO -ne 0 ]; then
 fi
 
 if [ $GOLR -ne 0 ]; then
-   echo "Starting the jetty server with Solr installed"
+   echo "Starting crond"
+   /etc/init.d/cron start
+   echo "Starting monit which will start the jetty server with Solr installed"
    /etc/init.d/monit start
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-###
-### AmiGO on Apache first.
-###
-
 AMIGO="${AMIGO:=1}" 
 GOLR="${GOLR:=1}" 
 
@@ -32,16 +28,15 @@ if [ $AMIGO -ne 0 ]; then
 
    echo "Starting the apache2 server with amigo installed"
    /etc/init.d/apache2 start
-   sleep 1
-   /etc/init.d/apache2 status
 fi
 
 if [ $GOLR -ne 0 ]; then
-   echo "Starting crond"
-   /etc/init.d/cron start
    echo "Starting monit which will start the jetty server with Solr installed"
    /etc/init.d/monit start
 fi
+
+echo "Starting crond"
+/etc/init.d/cron start
 
 cd /srv/amigo
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,11 +37,8 @@ if [ $AMIGO -ne 0 ]; then
 fi
 
 if [ $GOLR -ne 0 ]; then
-   SOLR_MEM=${GOLR_SOLR_MEMORY:="4G"}
-
-   echo "Starting the jetty server with Solr installed ($SOLR_MEM)"
-   cd /usr/share/jetty9
-   java -Xms$SOLR_MEM -Xmx$SOLR_MEM -DentityExpansionLimit=8172000 -Djava.awt.headless=true -Dsolr.solr.home=/srv/solr -Djava.io.tmpdir=/tmp/jetty9 -Djava.library.path=/usr/lib -Djetty.home=/usr/share/jetty9 -Djetty.logs=/var/log/jetty9 -Djetty.state=/tmp/jetty.state -Djetty.host=0.0.0.0 -Djetty.port=8080 -jar /usr/share/jetty9/start.jar --daemon /etc/jetty9/jetty-started.xml &
+   echo "Starting the jetty server with Solr installed"
+   /etc/init.d/monit start
 fi
 
 cd /srv/amigo

--- a/docker/java
+++ b/docker/java
@@ -1,0 +1,6 @@
+check process java 
+        matching "java"
+        start program = "/run-golr.sh"
+        stop program = "/usr/bin/killall java"
+        if loadavg (5min) > 3 then restart
+        if failed port 8080 then restart

--- a/docker/java-golr-monit
+++ b/docker/java-golr-monit
@@ -2,5 +2,4 @@ check process java
         matching "java"
         start program = "/run-golr.sh"
         stop program = "/usr/bin/killall java"
-        if loadavg (5min) > 3 then restart
         if failed port 8080 then restart

--- a/docker/run-golr.sh
+++ b/docker/run-golr.sh
@@ -2,6 +2,8 @@
 
 SOLR_MEM=${GOLR_SOLR_MEMORY:="4G"}
 
+killall java
 echo "Starting the jetty server with Solr installed ($SOLR_MEM)"
+mkdir -p /var/log/jetty9
 cd /usr/share/jetty9
-java -Xms$SOLR_MEM -Xmx$SOLR_MEM -DentityExpansionLimit=8172000 -Djava.awt.headless=true -Dsolr.solr.home=/srv/solr -Djava.io.tmpdir=/tmp/jetty9 -Djava.library.path=/usr/lib -Djetty.home=/usr/share/jetty9 -Djetty.logs=/var/log/jetty9 -Djetty.state=/tmp/jetty.state -Djetty.host=0.0.0.0 -Djetty.port=8080 -jar /usr/share/jetty9/start.jar --daemon /etc/jetty9/jetty-started.xml &
+java -Xms$SOLR_MEM -Xmx$SOLR_MEM -DentityExpansionLimit=8172000 -Djava.awt.headless=true -Dsolr.solr.home=/srv/solr -Djava.io.tmpdir=/tmp/jetty9 -Djava.library.path=/usr/lib -Djetty.home=/usr/share/jetty9 -Djetty.state=/tmp/jetty.state -Djetty.http.host=0.0.0.0 -Djetty.http.port=8080 -jar /usr/share/jetty9/start.jar --daemon /etc/jetty9/jetty-started.xml /etc/jetty9/console-capture.xml &

--- a/docker/run-golr.sh
+++ b/docker/run-golr.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+SOLR_MEM=${GOLR_SOLR_MEMORY:="4G"}
+
+echo "Starting the jetty server with Solr installed ($SOLR_MEM)"
+cd /usr/share/jetty9
+java -Xms$SOLR_MEM -Xmx$SOLR_MEM -DentityExpansionLimit=8172000 -Djava.awt.headless=true -Dsolr.solr.home=/srv/solr -Djava.io.tmpdir=/tmp/jetty9 -Djava.library.path=/usr/lib -Djetty.home=/usr/share/jetty9 -Djetty.logs=/var/log/jetty9 -Djetty.state=/tmp/jetty.state -Djetty.host=0.0.0.0 -Djetty.port=8080 -jar /usr/share/jetty9/start.jar --daemon /etc/jetty9/jetty-started.xml &

--- a/provision/stage.yaml
+++ b/provision/stage.yaml
@@ -96,10 +96,13 @@
       - not CREATE_INDEX
       - not index_result.stat.exists
 
-  - name: Create proxy-configs directory
+  - name: Create config directories
     file:
-      path: '{{ stage_dir }}/proxy-configs'
+      path: '{{ stage_dir }}/{{ item }}'
       state: directory
+    with_items:
+      - proxy-configs 
+      - golr-configs
 
   - name: install docker-compose.yaml and http configs ...
     template:
@@ -113,3 +116,5 @@
       - { file: 'httpd-vhosts-amigo.conf', dir: '/proxy-configs' }
       - { file: 'httpd-vhosts-golr.conf', dir: '/proxy-configs' }
       - { file: 's3cfg', dir: '/proxy-configs' }
+      - { file: 'java-golr-monit', dir: '/golr-configs' }
+      - { file: 'console-capture-golr.xml', dir: '/golr-configs' }

--- a/provision/stage.yaml
+++ b/provision/stage.yaml
@@ -103,16 +103,17 @@
     with_items:
       - proxy-configs 
       - golr-configs
+      - amigo-configs
 
   - name: install docker-compose.yaml and http configs ...
     template:
       src: 'templates/{{ item.file }}'
       dest: '{{ stage_dir }}{{ item.dir }}/{{ item.file }}'
     with_items:
-      - { file: 'amigo.yaml', dir: '/' }
-      - { file: '001-inline-amigo.conf', dir: '/' }
-      - { file: 'apache2.ports.conf', dir: '/' }
       - { file: 'docker-compose.yaml', dir: '/' }
+      - { file: 'amigo.yaml', dir: '/amigo-configs' }
+      - { file: '001-inline-amigo.conf', dir: '/amigo-configs' }
+      - { file: 'apache2.ports.conf', dir: '/amigo-configs' }
       - { file: 'httpd-vhosts-amigo.conf', dir: '/proxy-configs' }
       - { file: 'httpd-vhosts-golr.conf', dir: '/proxy-configs' }
       - { file: 's3cfg', dir: '/proxy-configs' }

--- a/provision/templates/console-capture-golr.xml
+++ b/provision/templates/console-capture-golr.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="logging" class="org.eclipse.jetty.util.log.Log">
+    <New id="ServerLog" class="java.io.PrintStream">
+      <Arg>
+        <New class="org.eclipse.jetty.util.RolloverFileOutputStream">
+                <Arg><Property name="jetty.console-capture.dir" deprecated="jetty.logging.dir" default="/var/log/jetty9"/>/yyyy_mm_dd.jetty.log</Arg>
+          <Arg type="boolean"><Property name="jetty.console-capture.append" deprecated="jetty.logging.append" default="false"/></Arg>
+          <Arg type="int"><Property name="jetty.console-capture.retainDays" deprecated="jetty.logging.retainDays" default="{{ JETTY_RETAIN_LOGS_IN_DAYS }}"/></Arg>
+          <Arg>
+            <Call class="java.util.TimeZone" name="getTimeZone">
+              <Arg><Property name="jetty.console-capture.timezone" deprecated="jetty.logging.timezone" default="GMT"/></Arg>
+            </Call>
+          </Arg>
+          <Get id="ServerLogName" name="datedFilename"/>
+        </New>
+      </Arg>
+    </New>
+
+    <Get name="rootLogger">
+      <Call name="info"><Arg>Console stderr/stdout captured to <Ref refid="ServerLogName"/></Arg></Call>
+    </Get>
+    <Call class="java.lang.System" name="setErr"><Arg><Ref refid="ServerLog"/></Arg></Call>
+    <Call class="java.lang.System" name="setOut"><Arg><Ref refid="ServerLog"/></Arg></Call>
+</Configure>

--- a/provision/templates/docker-compose.yaml
+++ b/provision/templates/docker-compose.yaml
@@ -28,9 +28,9 @@ services:
       - {{ stage_dir }}/amigo_working_path:/tmp
       - {{ stage_dir }}/golr_timestamp.log:/tmp/golr_timestamp.log
       - {{ stage_dir }}/release-archive-doi.json:/tmp/release-archive-doi.json
-      - {{ stage_dir }}/amigo.yaml:/srv/amigo/conf/amigo.yaml
-      - {{ stage_dir }}/001-inline-amigo.conf:/etc/apache2/sites-available/001-inline-amigo.conf
-      - {{ stage_dir }}/apache2.ports.conf:/etc/apache2/ports.conf
+      - {{ stage_dir }}/amigo-configs/amigo.yaml:/srv/amigo/conf/amigo.yaml
+      - {{ stage_dir }}/amigo-configs/001-inline-amigo.conf:/etc/apache2/sites-available/001-inline-amigo.conf
+      - {{ stage_dir }}/amigo-configs/apache2.ports.conf:/etc/apache2/ports.conf
       - {{ stage_dir }}/apache_amigo_logs:/var/log/apache2
     restart: unless-stopped
     depends_on:

--- a/provision/templates/docker-compose.yaml
+++ b/provision/templates/docker-compose.yaml
@@ -9,9 +9,10 @@ services:
       - GOLR=1
       - AMIGO=0
     volumes:
-      - {{ repo_dir }}:/srv/amigo
+      - {{ stage_dir }}/golr-configs/java-golr-monit:/etc/monit/conf-enabled/java
+      - {{ stage_dir }}/golr-configs/console-capture-golr.xml:/etc/jetty9/console-capture.xml
       - {{ stage_dir }}/srv-solr-data:/srv/solr/data
-      - {{ stage_dir }}/amigo.yaml:/srv/amigo/conf/amigo.yaml
+      - {{ stage_dir }}/golr_logs:/var/log
     restart: unless-stopped
 
   amigo:

--- a/provision/templates/docker-compose.yaml
+++ b/provision/templates/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
       - {{ stage_dir }}/amigo_working_path:/tmp
       - {{ stage_dir }}/golr_timestamp.log:/tmp/golr_timestamp.log
       - {{ stage_dir }}/release-archive-doi.json:/tmp/release-archive-doi.json
-      - {{ stage_dir }}/srv-solr-data:/srv/solr/data
       - {{ stage_dir }}/amigo.yaml:/srv/amigo/conf/amigo.yaml
       - {{ stage_dir }}/001-inline-amigo.conf:/etc/apache2/sites-available/001-inline-amigo.conf
       - {{ stage_dir }}/apache2.ports.conf:/etc/apache2/ports.conf

--- a/provision/templates/docker-compose.yaml
+++ b/provision/templates/docker-compose.yaml
@@ -1,9 +1,10 @@
-version: '3'
+version: '3.7'
 services:
   golr:
     hostname: golr 
     container_name: golr 
     image: amigo:{{ tag }}
+    init: true
     environment:
       - GOLR=1
       - AMIGO=0
@@ -17,6 +18,7 @@ services:
     hostname: amigo
     container_name: amigo
     image: amigo:{{ tag }}
+    init: true
     environment:
       - GOLR=0
       - AMIGO=1
@@ -38,6 +40,7 @@ services:
     hostname: apache_amigo
     container_name: apache_amigo
     image: go-apache:{{ tag }}
+    init: true
     restart: unless-stopped
     environment:
       - USE_S3={{ USE_S3 }}

--- a/provision/templates/java-golr-monit
+++ b/provision/templates/java-golr-monit
@@ -1,0 +1,10 @@
+check system golr 
+        if loadavg (1min) > {{ LOAD_AVG }} then alert
+        if loadavg (5min) > {{ LOAD_AVG }} then exec "/run-golr.sh" 
+
+check process java 
+        matching "java"
+        start program = "/run-golr.sh"
+        stop program = "/usr/bin/killall java"
+        if failed port 8080 then restart
+        depend golr

--- a/provision/vars.yaml
+++ b/provision/vars.yaml
@@ -36,6 +36,12 @@ ACCESS_KEY: REPLACE_ME
 SECRET_KEY: REPLACE_ME
 S3_BUCKET: REPLACE_ME
 
+########
+# For golr monit and jetty.  
+#######`
+LOAD_AVG: 3
+JETTY_RETAIN_LOGS_IN_DAYS: 30
+
 #####
 AMIGO_DYNAMIC: amigo.example.com
 AMIGO_DYNAMIC_ALIAS: amigo.example.com


### PR DESCRIPTION
- added monit to golr container and tested by kill java process. 
- log rotation for jetty process 
- log rotation for monit
- log rotation for jetty using console-capture.xml config file
- log rotation for apache running inside amigo container
- setting init to true in docker compose otherwise we get defunct when killing child processes (daemons). Monit trips on this. 
- Reorganized stage_dir by adding amigo_configs and golr_configs 
- Tested using local and AWS deployment. 