### PR TITLE
using shell command for docker compose

### DIFF
--- a/provision/down_services.yaml
+++ b/provision/down_services.yaml
@@ -4,6 +4,10 @@
 
   tasks:
   - name: Tear down existing services
-    docker_compose:
-      project_src: '{{ stage_dir }}'
-      state: absent
+    shell: docker-compose -f {{ stage_dir }}/docker-compose.yaml down 
+    register: output
+    args:
+      executable: /bin/bash
+
+  - debug: msg={{ output.stderr.split('\n') }}
+    when: output.stderr != "" 

--- a/provision/start_services.yaml
+++ b/provision/start_services.yaml
@@ -4,8 +4,10 @@
 
   tasks:
   - name: Create and start services
-    docker_compose:
-      project_src: '{{ stage_dir }}'
+    shell: nohup docker-compose -f {{ stage_dir }}/docker-compose.yaml up -d
+    register: output
+    args:
+      executable: /bin/bash
 
   - name: Check status
     shell: |
@@ -16,4 +18,3 @@
     changed_when: False
 
   - debug: msg={{ output.stdout.split('\n') }}
-


### PR DESCRIPTION
ansible docker-compose module needs the python interpreter to be set when doing local testing and to install docker-compose python module.  It is turning out to be a headache much like the ansible docker  module. 