### PR TITLE
Add Models tab to gene product pages

### DIFF
--- a/conf/.initial_values.yaml
+++ b/conf/.initial_values.yaml
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.docker
+++ b/conf/examples/amigo.yaml.docker
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.jenkins-production-test
+++ b/conf/examples/amigo.yaml.jenkins-production-test
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.localhost
+++ b/conf/examples/amigo.yaml.localhost
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: 'Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.'
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.localhost-monarch
+++ b/conf/examples/amigo.yaml.localhost-monarch
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: 'Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.'
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.localhost-planteome
+++ b/conf/examples/amigo.yaml.localhost-planteome
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.localhost_docker_loader
+++ b/conf/examples/amigo.yaml.localhost_docker_loader
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: 'Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.'
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: https://api-sierra.geneontology.io
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.nakama
+++ b/conf/examples/amigo.yaml.nakama
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.noctua
+++ b/conf/examples/amigo.yaml.noctua
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.production
+++ b/conf/examples/amigo.yaml.production
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.public
+++ b/conf/examples/amigo.yaml.public
@@ -104,6 +104,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/conf/examples/amigo.yaml.tomodachi
+++ b/conf/examples/amigo.yaml.tomodachi
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: ''
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -276,6 +276,7 @@ var web_compilables = [
     'Grebe.js',
     'Matrix.js',
     'Medial.js',
+    'ModelDetails.js',
     'LandingGraphs.js',
     'LiveSearchGOlr.js',
     'LoadDetails.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -301,9 +301,9 @@ function _client_compile_task(file) {
             .exclude('ringo/httpclient')
             .transform('babelify', { 
                 presets: ["@babel/preset-env"],
-                // Some of its dependencies are only distributed as ES6 modules.
-                // That means that we need babelify to transform them (even though they're not our
-                // code) before they get to browserify. See: 
+                // Some dependencies are only distributed as ES6 modules. That means that we need
+                // babelify to transform them (even though they're not our code) before they get 
+                // bundled by browserify. See: 
                 // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
                 global: true,
                 ignore: [/\/node_modules\/(?!@geneontology|@stencil\/)/]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -309,6 +309,9 @@ function _client_compile_task(file) {
                 ignore: [/\/node_modules\/(?!@geneontology|@stencil\/)/]
             })
             .transform('brfs')
+            .transform('loose-envify', {
+                GO_API_URL: a['GO_API_URL'].value,
+            })
             .bundle()
             .on('error', function (err) {
                 console.log('Error while bundling ' + file);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -308,6 +308,7 @@ function _client_compile_task(file) {
                 global: true,
                 ignore: [/\/node_modules\/(?!@geneontology|@stencil\/)/]
             })
+            .transform('brfs')
             .bundle()
             .on('error', function (err) {
                 console.log('Error while bundling ' + file);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -301,6 +301,12 @@ function _client_compile_task(file) {
             .exclude('ringo/httpclient')
             .transform('babelify', { 
                 presets: ["@babel/preset-env"],
+                // Some of its dependencies are only distributed as ES6 modules.
+                // That means that we need babelify to transform them (even though they're not our
+                // code) before they get to browserify. See: 
+                // https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
+                global: true,
+                ignore: [/\/node_modules\/(?!@geneontology|@stencil\/)/]
             })
             .bundle()
             .on('error', function (err) {

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -292,7 +292,9 @@ function GPDetailsInit(){
     // Initiate the request to get list of models for the GP
     var base = process.env.GO_API_URL;
     var endpoint = `/api/gp/${global_acc}/models`;
-    var query = {};
+    var query = {
+        'causalmf': '2',
+    };
     gocam_fetch_engine.start(base + endpoint, query, 'GET');
     models_tab.text(`${models_tab_title} (pending...)`);
 

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -224,6 +224,7 @@ function GPDetailsInit(){
     var gocam_viz = null;
     var gocam_no_data_message = jQuery('#gocam-no-data-message');
     var gocam_fetch_error_message = jQuery('#gocam-fetch-error-message');
+    var models_tab = jQuery('a[href=#display-models-tab]');
 
     jQuery('#gocam-viz-legend').attr('src', gocam_viz_legend_url);
 
@@ -262,6 +263,7 @@ function GPDetailsInit(){
         gocam_no_data_message.addClass('hidden');
         gocam_select_group.addClass('hidden');
         gocam_viz_container.addClass('hidden');
+        models_tab.text('Models');
     });
 
     // When we successfully retrieve a list of models ensure the error message
@@ -272,6 +274,7 @@ function GPDetailsInit(){
         gocam_fetch_error_message.addClass('hidden');
         gocam_select.empty();
         var body = resp.raw();
+        models_tab.text(`Models (${body.models.length})`);
         if (body.models && body.models.length > 0) {
             gocam_no_data_message.addClass('hidden');
             gocam_select_group.removeClass('hidden');
@@ -297,6 +300,7 @@ function GPDetailsInit(){
         expand: true
     };
     barista_engine.start(base + endpoint, query, 'GET');
+    models_tab.text('Models (pending...)');
 
     //
     ll('GPDetailsInit done.');

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -253,12 +253,11 @@ function GPDetailsInit(){
             gocam_viz_container.prepend(gocam_viz);
         }
     });
-    var barista_engine = new jquery_engine(rest_response);
-
+    var gocam_fetch_engine = new jquery_engine(rest_response);
     // If the request to get models for this GP fails, show an error message
     // and ensure the model selector, go-cam widget, and "no data" message are
     // all hidden.
-    barista_engine.register('error', function () {
+    gocam_fetch_engine.register('error', function () {
         gocam_fetch_error_message.removeClass('hidden');
         gocam_no_data_message.addClass('hidden');
         gocam_select_group.addClass('hidden');
@@ -270,17 +269,17 @@ function GPDetailsInit(){
     // is hidden. Then if there are models in the response, populate the select
     // box with those models as options. If there were no models in the response
     // show the "no data" message instead of the select box.
-    barista_engine.register('success', function (resp) {
+    gocam_fetch_engine.register('success', function (resp) {
         gocam_fetch_error_message.addClass('hidden');
         gocam_select.empty();
-        var body = resp.raw();
-        models_tab.text(`Models (${body.models.length})`);
-        if (body.models && body.models.length > 0) {
+        var models = resp.raw();
+        models_tab.text(`Models (${models.length})`);
+        if (models && models.length > 0) {
             gocam_no_data_message.addClass('hidden');
             gocam_select_group.removeClass('hidden');
             gocam_viz_container.removeClass('hidden');
-            body.models.forEach(function (model) {
-                gocam_select.append(`<option value=${model.id}>${model.title}</option>`);
+            models.forEach(function (model) {
+                gocam_select.append(`<option value=${model.gocam}>${model.title}</option>`);
             });
         } else {
             gocam_no_data_message.removeClass('hidden');
@@ -290,16 +289,10 @@ function GPDetailsInit(){
     });
 
     // Initiate the request to get list of models for the GP
-    var base = 'http://barista.berkeleybop.org';
-    var endpoint = '/search/models';
-    // TODO: handle case where reponse returns more than 100 models
-    var query = {
-        offset: 0,
-        limit: 100,
-        gp: global_acc,
-        expand: true
-    };
-    barista_engine.start(base + endpoint, query, 'GET');
+    var base = 'http://api-sierra.geneontology.io';
+    var endpoint = `/api/gp/${global_acc}/models`;
+    var query = {};
+    gocam_fetch_engine.start(base + endpoint, query, 'GET');
     models_tab.text('Models (pending...)');
 
     //

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -225,6 +225,7 @@ function GPDetailsInit(){
     var gocam_no_data_message = jQuery('#gocam-no-data-message');
     var gocam_fetch_error_message = jQuery('#gocam-fetch-error-message');
     var models_tab = jQuery('a[href=#display-models-tab]');
+    var models_tab_title = 'GO-CAMs';
 
     jQuery('#gocam-viz-legend').attr('src', gocam_viz_legend_url);
 
@@ -262,7 +263,7 @@ function GPDetailsInit(){
         gocam_no_data_message.addClass('hidden');
         gocam_select_group.addClass('hidden');
         gocam_viz_container.addClass('hidden');
-        models_tab.text('Models');
+        models_tab.text(models_tab_title);
     });
 
     // When we successfully retrieve a list of models ensure the error message
@@ -273,7 +274,7 @@ function GPDetailsInit(){
         gocam_fetch_error_message.addClass('hidden');
         gocam_select.empty();
         var models = resp.raw();
-        models_tab.text(`Models (${models.length})`);
+        models_tab.text(`${models_tab_title} (${models.length})`);
         if (models && models.length > 0) {
             gocam_no_data_message.addClass('hidden');
             gocam_select_group.removeClass('hidden');
@@ -293,7 +294,7 @@ function GPDetailsInit(){
     var endpoint = `/api/gp/${global_acc}/models`;
     var query = {};
     gocam_fetch_engine.start(base + endpoint, query, 'GET');
-    models_tab.text('Models (pending...)');
+    models_tab.text(`${models_tab_title} (pending...)`);
 
     //
     ll('GPDetailsInit done.');

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -17,6 +17,11 @@ var html = widgets.html;
 
 require('@geneontology/wc-gocam-viz/dist/custom-elements').defineCustomElements();
 
+// using 'fs' here is enabled by https://www.npmjs.com/package/brfs
+var fs = require('fs');
+var gocam_viz_legend_data = fs.readFileSync('node_modules/@geneontology/wc-gocam-viz/dist/wc-gocam-viz/assets/legendv2.png', 'base64');
+var gocam_viz_legend_url = 'data:image/png;base64,' + gocam_viz_legend_data;
+
 // Config.
 var amigo = new (require('amigo2-instance-data'))(); // no overload
 var golr_conf = require('golr-conf');
@@ -58,7 +63,7 @@ function GPDetailsInit(){
     var dtabs = jQuery("#display-tabs");
     if (dtabs) {
         ll('Apply tabs...');
-        var fragname = window?.location?.hash
+        var fragname = window.location && window.location.hash
         if (fragname && fragname !== "#") {
             jQuery('#display-tabs a[href="' + fragname + '"]').tab('show');
         } else {
@@ -220,6 +225,8 @@ function GPDetailsInit(){
     var gocam_no_data_message = jQuery('#gocam-no-data-message');
     var gocam_fetch_error_message = jQuery('#gocam-fetch-error-message');
 
+    jQuery('#gocam-viz-legend').attr('src', gocam_viz_legend_url);
+
     // When the model select box changes, inform the go-cam widget of the new
     // model ID.
     gocam_select.on('change', function () {
@@ -242,7 +249,7 @@ function GPDetailsInit(){
             gocam_viz.setAttribute('show-gene-product', 'true');
             gocam_viz.setAttribute('show-activity', 'false');
             gocam_viz.setAttribute('show-legend', 'false');
-            gocam_viz_container.append(gocam_viz);
+            gocam_viz_container.prepend(gocam_viz);
         }
     });
     var barista_engine = new jquery_engine(rest_response);

--- a/javascript/web/GPDetails.js
+++ b/javascript/web/GPDetails.js
@@ -289,7 +289,7 @@ function GPDetailsInit(){
     });
 
     // Initiate the request to get list of models for the GP
-    var base = 'http://api-sierra.geneontology.io';
+    var base = process.env.GO_API_URL;
     var endpoint = `/api/gp/${global_acc}/models`;
     var query = {};
     gocam_fetch_engine.start(base + endpoint, query, 'GET');

--- a/javascript/web/ModelDetails.js
+++ b/javascript/web/ModelDetails.js
@@ -1,0 +1,1 @@
+require('@geneontology/wc-gocam-viz/dist/custom-elements').defineCustomElements();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,6 +1300,97 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@geneontology/dbxrefs": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@geneontology/dbxrefs/-/dbxrefs-1.0.16.tgz",
+      "integrity": "sha512-zKvbcfs+LU4ZnUo00A5ae0V+FVMIM4ftxcfKtJWmtnLKwWy1sOn2y36HGcz/rEmLwd2zBApKJ0ojmgBH416Q5Q==",
+      "requires": {
+        "axios": "^0.21.1",
+        "js-yaml": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@geneontology/wc-gocam-viz": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-gocam-viz/-/wc-gocam-viz-0.0.48.tgz",
+      "integrity": "sha512-28YFI/BkZqzrj3rOA4tDjWZFypqF+tYb7J1t6p6/zNp/yd7MXfRzSynu4BSABUvoC3wz/kG/31FHJ+KN3m5mFQ==",
+      "requires": {
+        "@geneontology/dbxrefs": "^1.0.16",
+        "@geneontology/wc-light-modal": "0.0.7",
+        "@stencil/core": "^2.10.0",
+        "bbop-graph-noctua": "0.0.35",
+        "cytoscape": "^3.16.1",
+        "cytoscape-cose-bilkent": "^4.1.0"
+      },
+      "dependencies": {
+        "bbop-graph-noctua": {
+          "version": "0.0.35",
+          "resolved": "https://registry.npmjs.org/bbop-graph-noctua/-/bbop-graph-noctua-0.0.35.tgz",
+          "integrity": "sha512-DmIXvTWRG4ryBwPUZT+RpNxK6eewFzXPNB5cEgXhGttbNitriZOI02BDBwHqaZMJ7CHWKSOwEBc2JqJN/rOJGw==",
+          "requires": {
+            "bbop-core": "0.0.5",
+            "bbop-graph": "0.0.19",
+            "class-expression": "0.0.11",
+            "underscore": "1.8.3"
+          }
+        },
+        "class-expression": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/class-expression/-/class-expression-0.0.11.tgz",
+          "integrity": "sha512-kJwAmGIPhFJjgVDHRyouXLVwF/tzSQUPdvaPG4Uc4xyt5RXaPDCXyw49endcfsfjmZzfRxycrSzC+Xn9z7eHPw==",
+          "requires": {
+            "bbop-core": "0.0.5",
+            "underscore": "1.8.3"
+          }
+        },
+        "cytoscape": {
+          "version": "3.23.0",
+          "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.23.0.tgz",
+          "integrity": "sha512-gRZqJj/1kiAVPkrVFvz/GccxsXhF3Qwpptl32gKKypO4IlqnKBjTOu+HbXtEggSGzC5KCaHp3/F7GgENrtsFkA==",
+          "requires": {
+            "heap": "^0.2.6",
+            "lodash": "^4.17.21"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "@geneontology/wc-light-modal": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@geneontology/wc-light-modal/-/wc-light-modal-0.0.7.tgz",
+      "integrity": "sha512-7jUATAbdQJBGSDqmvXU/qWVUTAQPd7zOm5tyRZQNDDtGJMAx7wp+DZrxN8XEhkYclbUs+/3XFspF7KQtMf4FQg==",
+      "requires": {
+        "@stencil/core": "^1.8.8"
+      },
+      "dependencies": {
+        "@stencil/core": {
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.17.4.tgz",
+          "integrity": "sha512-dmuNYM6fnHPvE2ptHoUBQtjcpXqrHnkDtdyUD6/JrZWcJt6jBtrykewObOxzpDCMLs+NT7668ussRagdVL03gQ==",
+          "requires": {
+            "typescript": "3.9.7"
+          }
+        }
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -1398,6 +1489,11 @@
         "d3-collection": "1",
         "d3-interpolate": "1"
       }
+    },
+    "@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng=="
     },
     "JSONStream": {
       "version": "1.0.7",
@@ -2002,6 +2098,14 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
@@ -3943,6 +4047,14 @@
         "vary": "^1"
       }
     },
+    "cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "requires": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
@@ -4160,6 +4272,14 @@
       "requires": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"
+      }
+    },
+    "cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "requires": {
+        "cose-base": "^1.0.0"
       }
     },
     "cytoscape-dagre": {
@@ -5571,6 +5691,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "font-atlas-sdf": {
       "version": "1.3.3",
@@ -8283,6 +8408,11 @@
       "requires": {
         "package-json": "^4.0.0"
       }
+    },
+    "layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -15067,6 +15197,11 @@
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,6 +8780,15 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1873,6 +1873,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "dev": true
+    },
     "array-initial": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
@@ -2934,57 +2940,106 @@
       }
     },
     "brfs": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
-      "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-2.0.2.tgz",
+      "integrity": "sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==",
+      "dev": true,
       "requires": {
         "quote-stream": "^1.0.1",
         "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
+        "static-module": "^3.0.2",
         "through2": "^2.0.0"
       },
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+          "dev": true,
           "requires": {
             "readable-stream": "^2.0.2"
           }
         },
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.1"
+          }
+        },
         "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+          "dev": true
         },
         "quote-stream": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-          "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+          "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
+          "dev": true,
           "requires": {
             "buffer-equal": "0.0.1",
             "minimist": "^1.1.3",
             "through2": "^2.0.0"
           }
         },
-        "static-module": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.4.tgz",
-          "integrity": "sha512-qlzhn8tYcfLsXK2RTWtkx1v/cqiPtS9eFy+UmQ9UnpEDYcwtgbceOybnKp5JncsOnLI/pyGeyzI9Bej9tv0xiA==",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
+        "static-eval": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+          "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+          "dev": true,
           "requires": {
+            "escodegen": "^1.11.1"
+          }
+        },
+        "static-module": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+          "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
+          "dev": true,
+          "requires": {
+            "acorn-node": "^1.3.0",
             "concat-stream": "~1.6.0",
             "convert-source-map": "^1.5.1",
             "duplexer2": "~0.1.4",
-            "escodegen": "~1.9.0",
-            "falafel": "^2.1.0",
+            "escodegen": "^1.11.1",
             "has": "^1.0.1",
-            "magic-string": "^0.22.4",
+            "magic-string": "0.25.1",
             "merge-source-map": "1.0.4",
-            "object-inspect": "~1.4.0",
-            "quote-stream": "~1.0.2",
+            "object-inspect": "^1.6.0",
             "readable-stream": "~2.3.3",
+            "scope-analyzer": "^2.0.1",
             "shallow-copy": "~0.0.1",
-            "static-eval": "^2.0.0",
+            "static-eval": "^2.0.5",
             "through2": "~2.0.3"
           }
         }
@@ -3302,7 +3357,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-from": {
       "version": "1.0.0",
@@ -4389,6 +4444,12 @@
         }
       }
     },
+    "dash-ast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-2.0.1.tgz",
+      "integrity": "sha512-5TXltWJGc+RdnabUGzhRae1TRq6m4gr+3K2wQX0is5/F2yS6MJXJvLyI3ErAnsAXuJoGqvfVD5icRgim07DrxQ==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4861,10 +4922,46 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+    },
+    "es6-set": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
+      "integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "^3.1.3",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+          "dev": true
+        }
+      }
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -4942,6 +5039,12 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
+    "estree-is-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
+      "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -4951,6 +5054,16 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
       "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "events": {
       "version": "1.1.1",
@@ -6376,6 +6489,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.1.0.tgz",
       "integrity": "sha512-zP1xt0FujtripugkeJjpb6WEP0Mi5eWMzr9ALpjp7p0dXt/GB1PmzNnbFdEFrzDtB9rUPjxw0WYQhGqhmuSpsQ=="
+    },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -8785,6 +8904,17 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         },
+        "brfs": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+          "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+          "requires": {
+            "quote-stream": "^1.0.1",
+            "resolve": "^1.1.5",
+            "static-module": "^2.2.0",
+            "through2": "^2.0.0"
+          }
+        },
         "buble": {
           "version": "0.15.2",
           "resolved": "https://registry.npmjs.org/buble/-/buble-0.15.2.tgz",
@@ -8815,6 +8945,14 @@
             "object-assign": "^4.0.1"
           }
         },
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
         "magic-string": {
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
@@ -8827,6 +8965,59 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "object-inspect": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
+        },
+        "quote-stream": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+          "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
+          "requires": {
+            "buffer-equal": "0.0.1",
+            "minimist": "^1.1.3",
+            "through2": "^2.0.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+              "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+            }
+          }
+        },
+        "static-module": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
+          "requires": {
+            "concat-stream": "~1.6.0",
+            "convert-source-map": "^1.5.1",
+            "duplexer2": "~0.1.4",
+            "escodegen": "~1.9.0",
+            "falafel": "^2.1.0",
+            "has": "^1.0.1",
+            "magic-string": "^0.22.4",
+            "merge-source-map": "1.0.4",
+            "object-inspect": "~1.4.0",
+            "quote-stream": "~1.0.2",
+            "readable-stream": "~2.3.3",
+            "shallow-copy": "~0.0.1",
+            "static-eval": "^2.0.0",
+            "through2": "~2.0.3"
+          },
+          "dependencies": {
+            "magic-string": {
+              "version": "0.22.5",
+              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+              "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+              "requires": {
+                "vlq": "^0.2.2"
+              }
+            }
+          }
         }
       }
     },
@@ -8975,7 +9166,7 @@
     "merge-source-map": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -13569,6 +13760,21 @@
       "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-2.0.0.tgz",
       "integrity": "sha1-QOJXNqKMTM6qojP0W7hjc6J4W4Q="
     },
+    "scope-analyzer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-2.1.2.tgz",
+      "integrity": "sha512-5cfCmsTYV/wPaRIItNxatw02ua/MThdIUNnUOCYp+3LSEJvnG804ANw2VLaavNILIfWXF1D1G2KNANkBBvInwQ==",
+      "dev": true,
+      "requires": {
+        "array-from": "^2.1.1",
+        "dash-ast": "^2.0.1",
+        "es6-map": "^0.1.5",
+        "es6-set": "^0.1.5",
+        "es6-symbol": "^3.1.1",
+        "estree-is-function": "^1.0.0",
+        "get-assigned-identifiers": "^1.1.0"
+      }
+    },
     "seedrandom": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
@@ -14216,6 +14422,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "sparkles": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "npm": ">= 5.6.0"
   },
   "dependencies": {
+    "@geneontology/wc-gocam-viz": "0.0.48",
     "bbop": "2.4.3",
     "bbop-core": "0.0.5",
     "bbop-graph": "0.0.19",
@@ -75,7 +76,7 @@
     "npm-check-updates": "^2.14.1",
     "vinyl-source-stream": "2.0.0"
   },
-  "browserify": { 
+  "browserify": {
     "transform": [
       "browserify-shim"
     ]

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "gulp": "^4.0.2",
     "gulp-bump": "^3.1.0",
     "gulp-develop-server": "0.5.2",
+    "loose-envify": "^1.4.0",
     "mocha": "5.0.5",
     "node-cache": "4.2.0",
     "npm-check-updates": "^2.14.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@babel/core": "^7.21.3",
     "@babel/preset-env": "^7.20.2",
     "babelify": "^10.0.0",
+    "brfs": "^2.0.2",
     "browserify": "^16.1.1",
     "browserify-css": "^0.15.0",
     "browserify-shim": "^3.8.6",

--- a/perl/lib/AmiGO/WebApp/HTMLClient.pm
+++ b/perl/lib/AmiGO/WebApp/HTMLClient.pm
@@ -2118,17 +2118,18 @@ sub mode_model_details {
   ## revisit later on.
   my $github_base =
     'https://github.com/geneontology/noctua-models/blob/master/models/';
+  my $github_file_ext = '.ttl';
   my $noctua_base = $self->{WEBAPP_TEMPLATE_PARAMS}{noctua_base};
   my $editor_base = $noctua_base . 'editor/graph/';
-  my $viewer_base = $noctua_base . 'workbench/cytoview/';
+  my $viewer_base = $noctua_base . 'workbench/noctua-visual-pathway-editor/?model_id=';
   ## We need to translate some of the document information.
   ## TODO/BUG: This is temporary as we work out what we'll actually have.
   my @s = split(':', $input_id);
   my $fid = $s[scalar(@s) -1];
   ##
-  my $repo_file_url = $github_base . $fid;
-  my $edit_file_url = $editor_base . $input_id;
-  my $view_file_url = $viewer_base . $input_id;
+  my $repo_file_url = $github_base . $fid . $github_file_ext;
+  my $edit_file_url = $editor_base . $ma_info_hash->{'model_id'};
+  my $view_file_url = $viewer_base . $ma_info_hash->{'model_id'};
   $self->set_template_parameter('repo_file_url', $repo_file_url);
   $self->set_template_parameter('edit_file_url', $edit_file_url);
   $self->set_template_parameter('view_file_url', $view_file_url);

--- a/perl/lib/AmiGO/WebApp/HTMLClient.pm
+++ b/perl/lib/AmiGO/WebApp/HTMLClient.pm
@@ -2064,17 +2064,17 @@ sub mode_model_details {
   my $ma_info_hash;
   $ma_info_hash->{'model_id'} = $response->{'id'};
   my $model_annotations = $response->{'annotations'};
-  my $comments;
   foreach my $annotation (@$model_annotations) {
     if ( $annotation->{'key'} eq 'title' ) {
       $ma_info_hash->{'model_label'} = $annotation->{'value'};
     } elsif ( $annotation->{'key'} eq 'state' ) {
       $ma_info_hash->{'model_state'} = $annotation->{'value'};
-    } elsif ( $annotation->{'key'} eq 'comment' ) {
-      push @$comments, $annotation->{'value'};
+    } elsif ( $annotation->{'key'} eq 'wasDerivedFrom' ) {
+      $ma_info_hash->{'derived_from_id'} = $annotation->{'value'};
+      $ma_info_hash->{'derived_from_link'} = $self->{CORE}->get_interlink({mode => 'model_details', 
+          arg => {acc=>$annotation->{'value'}}});
     }
   }
-  $ma_info_hash->{'model_comment'} = $comments;
 
   $self->{CORE}->kvetch('model info: ' . Dumper($ma_info_hash));
   $self->set_template_parameter('MA_INFO', $ma_info_hash);
@@ -2119,20 +2119,13 @@ sub mode_model_details {
   my $github_base =
     'https://github.com/geneontology/noctua-models/blob/master/models/';
   my $github_file_ext = '.ttl';
-  my $noctua_base = $self->{WEBAPP_TEMPLATE_PARAMS}{noctua_base};
-  my $editor_base = $noctua_base . 'editor/graph/';
-  my $viewer_base = $noctua_base . 'workbench/noctua-visual-pathway-editor/?model_id=';
   ## We need to translate some of the document information.
   ## TODO/BUG: This is temporary as we work out what we'll actually have.
   my @s = split(':', $input_id);
   my $fid = $s[scalar(@s) -1];
   ##
   my $repo_file_url = $github_base . $fid . $github_file_ext;
-  my $edit_file_url = $editor_base . $ma_info_hash->{'model_id'};
-  my $view_file_url = $viewer_base . $ma_info_hash->{'model_id'};
   $self->set_template_parameter('repo_file_url', $repo_file_url);
-  $self->set_template_parameter('edit_file_url', $edit_file_url);
-  $self->set_template_parameter('view_file_url', $view_file_url);
 
   ## Our AmiGO services CSS.
   my $prep =

--- a/static/css/amigo.css
+++ b/static/css/amigo.css
@@ -194,3 +194,94 @@ a:hover .hilite, a:active .hilite {
 .alert-warning .alert-link {
     color: #3b2e18;
 }
+
+/* Begin wc-gocam-viz widget customization */
+:root {
+    --gocam-width: 800px;
+    --gocam-height: 800px;
+    --gocam-border-radius: 3px;
+    --gocam-border-size: 0px;
+    --gocam-box-shadow: none;
+    --gocam-panel-box-shadow: none;
+    --gocam-panel-h1-color: rgb(51, 51, 51);
+    --gocam-panel-process-color: none;
+    --gocam-panel-process-font-color: black;
+    --gocam-panel-process-hover-font-color: black;
+    --gocam-panel-process-font-weight: 500;
+}
+.gocam-viz {
+    padding: 0;
+}
+.gocam-viz-container {
+    white-space: nowrap;
+    min-height: var(--gocam-height);
+}
+.h1-gcv {
+    text-align: left;
+    font-size: 18px;
+    font-weight: 500;
+    margin: 0 0 8px 0;
+}
+.genes-panel__container__title {
+    margin: 0;
+}
+.genes-panel__container__title hr {
+    display: none;
+}
+.genes-panel__list {
+    height: calc(100% - 20px);
+    position: relative;  /* to correct genes-panel__item offsetParent */
+}
+.genes-panel__item {
+    box-shadow: none !important;
+    margin: 0;
+    padding: 5px;
+    border-radius: 0;
+    border-bottom: 1px solid #ddd;
+}
+.genes-panel__item:hover {
+    box-shadow: none;
+    background-color: #e9effa;
+}
+.genes-panel__item:last-child {
+    border: none;
+}
+.genes-panel__item.gp_item_selected {
+    background-color: #e9effa;
+}
+.genes-panel__item__activity {
+    margin: 0 !important;
+}
+.genes-panel__item__process {
+    box-shadow: none;
+    border: none;
+    margin: 0 0 24px 0;
+}
+.genes-panel__item__process__activities {
+    padding: 0;
+    margin: 0;
+}
+.genes-panel__item__process__list {
+    border-color: #ddd;
+    border-width: 0 0 2px 0;
+    border-radius: 0;
+    padding: 5px;
+    position: sticky;
+    top: 0;
+    background-color: white;
+}
+.genes-panel__item__process__list-name {
+    font-size: 14px;
+    padding: 0;
+}
+.genes-panel__item__title {
+    font-size: inherit;
+    font-weight: normal;
+    color: inherit;
+}
+.genes-panel__item__title__gp {
+    color: inherit;
+}
+.genes-panel__item__title__gp__taxon {
+    font-size: inherit;
+}

--- a/static/css/amigo.css
+++ b/static/css/amigo.css
@@ -195,6 +195,15 @@ a:hover .hilite, a:active .hilite {
     color: #3b2e18;
 }
 
+.btn-collapse-toggle .glyphicon {
+    transition: transform 350ms ease;
+    transform: rotate(180deg);
+}
+
+.btn-collapse-toggle.collapsed .glyphicon {
+    transform: none;
+}
+
 /* Begin wc-gocam-viz widget customization */
 :root {
     --gocam-width: 800px;

--- a/templates/html/bs3/common/annotation_search.tmpl
+++ b/templates/html/bs3/common/annotation_search.tmpl
@@ -1,4 +1,4 @@
-<!-- START template: live_search.tmpl -->
+<!-- START template: annotation_search.tmpl -->
 
 <div id="results-area" class="row">
   <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3">
@@ -17,3 +17,5 @@
       </div>
   </div>
 </div>
+
+<!-- END template: annotation_search.tmpl -->

--- a/templates/html/bs3/common/live_search.tmpl
+++ b/templates/html/bs3/common/live_search.tmpl
@@ -1,0 +1,19 @@
+<!-- START template: live_search.tmpl -->
+
+<div id="results-area" class="row">
+  <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3">
+    <div>
+      <h4>Filter results</h4>
+      <div id="accordion" class="bbop-widget-set-live-filters">
+        Loading...
+      </div>
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9">
+    <div id="pager" class="bbop-widget-set-live-pager"></div>
+      <div id="results" class="bbop-widget-set-live-results">
+        pending...
+      </div>
+  </div>
+</div>

--- a/templates/html/bs3/pages/gene_product_details.tmpl
+++ b/templates/html/bs3/pages/gene_product_details.tmpl
@@ -142,7 +142,7 @@
           </div>
         <div id="gocam-no-data-message" class="hidden">
           <p>No GO-CAM models associated with Gene Product [% GP_INFO.internal_id %]</p>
-          <p>To learn more about GO-CAM models visit <a href="https://geneontology.cloud/home">https://geneontology.cloud/home</a>.
+          <p>To learn more about GO-CAM models visit <a href="http://geneontology.org/go-cam">http://geneontology.org/go-cam</a>.
         </div>
         <div id="gocam-fetch-error-message" class="hidden">
           <p class="text-danger">Unable to retrieve GO-CAM model information for [% GP_INFO.internal_id %]. Try again later.</p>

--- a/templates/html/bs3/pages/gene_product_details.tmpl
+++ b/templates/html/bs3/pages/gene_product_details.tmpl
@@ -132,7 +132,14 @@
           <label for="gomodel-select">Available GO-CAM models</label>
           <select class="form-control" id="gomodel-select"></select>
         </div>
-        <div id="gp-gocam-viz-container" class="gocam-viz-container"></div>
+        <div id="gp-gocam-viz-container" class="gocam-viz-container">
+          <button class="btn btn-link btn-collapse-toggle collapsed" type="button" data-toggle="collapse" data-target="#gocam-viz-legend-container" aria-expanded="false" aria-controls="gocam-viz-legend-container">
+            Legend <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span> 
+          </button>
+          <div class="collapse" id="gocam-viz-legend-container">
+            <img width="566" id="gocam-viz-legend">
+          </div>
+          </div>
         <div id="gocam-no-data-message" class="hidden">
           <p>No GO-CAM models associated with Gene Product [% GP_INFO.internal_id %]</p>
           <p>To learn more about GO-CAM models visit <a href="https://geneontology.cloud/home">https://geneontology.cloud/home</a>.

--- a/templates/html/bs3/pages/gene_product_details.tmpl
+++ b/templates/html/bs3/pages/gene_product_details.tmpl
@@ -121,7 +121,7 @@
   <div id="display-associations-tab" class="tab-pane">
     <div class="panel panel-default amigo-detail-tab-spacer amigo-live-search-results-unbounder">
       <div class="panel-body">
-        [% INCLUDE "common/live_search.tmpl" %]
+        [% INCLUDE "common/annotation_search.tmpl" %]
       </div>
     </div>
   </div>

--- a/templates/html/bs3/pages/gene_product_details.tmpl
+++ b/templates/html/bs3/pages/gene_product_details.tmpl
@@ -107,36 +107,41 @@
   </div>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">Gene Product Associations</h3>
-  </div>
-  <div class="panel-body">
+<!-- Display tabbing. -->
+<ul id="display-tabs" class="nav nav-tabs">
+  <li>
+    <a href="#display-associations-tab" data-toggle="tab">Associations</a>
+  </li>
+  <li>
+    <a href="#display-models-tab" data-toggle="tab">Models</a>
+  </li>
+</ul>
 
-    <div id="results-area" class="row">
-
-	<div class="col-xs-12 col-sm-12 col-md-3 col-lg-3">
-	  <div>
-	    <h4>Filter results</h4>
-	    
-	    <div id="accordion" class="bbop-widget-set-live-filters">
-	      Loading...
-	    </div>
-
-	  </div>	  
-	</div>
-
-	<div class="col-xs-12 col-sm-12 col-md-9 col-lg-9">
-	  
-	  <div id="pager" class="bbop-widget-set-live-pager">
-	  </div>
-	  <div id="results" class="bbop-widget-set-live-results">
-	    pending...
-	  </div>
-	</div>
-
+<div class="tab-content">
+  <div id="display-associations-tab" class="tab-pane">
+    <div class="panel panel-default amigo-detail-tab-spacer amigo-live-search-results-unbounder">
+      <div class="panel-body">
+        [% INCLUDE "common/live_search.tmpl" %]
+      </div>
     </div>
-
+  </div>
+  <div id="display-models-tab" class="tab-pane">
+    <div class="panel panel-default amigo-detail-tab-spacer">
+      <div class="panel-body">
+        <div class="form-group hidden" id="gomodel-select-group">
+          <label for="gomodel-select">Available GO-CAM models</label>
+          <select class="form-control" id="gomodel-select"></select>
+        </div>
+        <div id="gp-gocam-viz-container" class="gocam-viz-container"></div>
+        <div id="gocam-no-data-message" class="hidden">
+          <p>No GO-CAM models associated with Gene Product [% GP_INFO.internal_id %]</p>
+          <p>To learn more about GO-CAM models visit <a href="https://geneontology.cloud/home">https://geneontology.cloud/home</a>.
+        </div>
+        <div id="gocam-fetch-error-message" class="hidden">
+          <p class="text-danger">Unable to retrieve GO-CAM model information for [% GP_INFO.internal_id %]. Try again later.</p>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/templates/html/bs3/pages/gene_product_details.tmpl
+++ b/templates/html/bs3/pages/gene_product_details.tmpl
@@ -113,7 +113,7 @@
     <a href="#display-associations-tab" data-toggle="tab">Associations</a>
   </li>
   <li>
-    <a href="#display-models-tab" data-toggle="tab">Models</a>
+    <a href="#display-models-tab" data-toggle="tab">GO-CAMs</a>
   </li>
 </ul>
 

--- a/templates/html/bs3/pages/model_details.tmpl
+++ b/templates/html/bs3/pages/model_details.tmpl
@@ -16,53 +16,30 @@
       <!-- <dd>(n/a)</dd> -->
       <!-- [% END %] -->
       
-      <dt>ID</dt>
-      [% IF MA_INFO.model_id %]
-      <dd>[% MA_INFO.model_id %]</dd>
-      [% ELSE %]
-      <dd>(n/a)</dd>
-      [% END %]
-      
-      <dt>Label</dt>
+      <dt>Title</dt>
       [% IF MA_INFO.model_label %]
       <dd>[% MA_INFO.model_label %]</dd>
       [% ELSE %]
       <dd>(n/a)</dd>
       [% END %]
       
-      <dt>State</dt>
-      [% IF MA_INFO.model_state %]
-      <dd>[% MA_INFO.model_state %]</dd>
+      <dt>Model ID</dt>
+      [% IF MA_INFO.model_id %]
+      <dd>[% MA_INFO.model_id %]</dd>
       [% ELSE %]
       <dd>(n/a)</dd>
       [% END %]
       
-      <dt>Comment</dt>
-      [% IF MA_INFO.model_comment %]
-      [%    FOREACH comm IN MA_INFO.model_comment %]
-      <dd>[% comm %]</dd>
-      [% END %]
+      <dt>Derived From</dt>
+      [% IF MA_INFO.derived_from_id %]
+      <dd><a href="[% MA_INFO.derived_from_link %]">[% MA_INFO.derived_from_id %]</a></dd>
       [% ELSE %]
       <dd>(n/a)</dd>
       [% END %]
       
-      <dt>File</dt>
+      <dt>Data file (ttl)</dt>
       [% IF MA_INFO.model_id %]
       <dd><a href="[% repo_file_url %]">[% MA_INFO.model_id %]</a> <small>(@GitHub)</small></dd>
-      [% ELSE %]
-      <dd>(n/a)</dd>
-      [% END %]
-      
-      <dt>View</dt>
-      [% IF MA_INFO.model_id %]
-      <dd><a href="[% view_file_url %]">CytoView Workbench</a> (Noctua)</dd>
-      [% ELSE %]
-      <dd>(n/a)</dd>
-      [% END %]
-      
-      <dt>Edit</dt>
-      [% IF MA_INFO.model_id %]
-      <dd><a href="[% edit_file_url %]">Noctua</a></dd>
       [% ELSE %]
       <dd>(n/a)</dd>
       [% END %]

--- a/templates/html/bs3/pages/model_details.tmpl
+++ b/templates/html/bs3/pages/model_details.tmpl
@@ -77,23 +77,18 @@
     <h3 class="panel-title">View</h3>
   </div>
   <div class="panel-body">
-    <div id="display-associations">
-
-      [% IF has_model_content_p %]
-
-      <div id="cytoview"
-	   width="100%" height="750px"
-	   style="border: 1px black solid; width:100%; height:750px; margin-top:5px;">
-	Loading...
-      </div>
-
-      [% ELSE %]
-
-      No model data is available for display.
-
-      [% END %]
-
-    </div>
+  [% IF MA_INFO.model_id %]
+    <wc-gocam-viz 
+      id="gocam-1"
+      gocam-id="[% MA_INFO.model_id %]"
+      show-go-cam-selector=false
+      show-has-input=false
+      show-has-output=false
+      show-gene-product=true
+      show-activity=false
+      show-legend=false
+    ></wc-gocam-viz>
+  [% END %]
   </div>
 </div>
 

--- a/templates/html/bs3/pages/term_details.tmpl
+++ b/templates/html/bs3/pages/term_details.tmpl
@@ -42,7 +42,7 @@
   <div id="display-associations-tab" class="tab-pane">
     <div class="panel panel-default amigo-detail-tab-spacer amigo-live-search-results-unbounder">
       <div class="panel-body">
-        [% INCLUDE "common/live_search.tmpl" %]
+        [% INCLUDE "common/annotation_search.tmpl" %]
       </div>
     </div>
   </div>

--- a/templates/html/bs3/pages/term_details.tmpl
+++ b/templates/html/bs3/pages/term_details.tmpl
@@ -42,7 +42,7 @@
   <div id="display-associations-tab" class="tab-pane">
     <div class="panel panel-default amigo-detail-tab-spacer amigo-live-search-results-unbounder">
       <div class="panel-body">
-	[% INCLUDE "common/term_details_search.tmpl" %]
+        [% INCLUDE "common/live_search.tmpl" %]
       </div>
     </div>
   </div>


### PR DESCRIPTION
These changes add a Models tab to gene product pages. 

* When the page is loaded it queries `http://barista.berkeleybop.org/search/models` for models that involve the gene product for that page. This endpoint will need to be changed later. It's being used here for the time being because unlike `https://api.geneontology.xyz/gp/{id}/models` it doesn't require a full identifiers.org URI. Hopefully the new GO API can take that into account, and once it is deployed we can use it instead of `http://barista.berkeleybop.org/search/models`.
* Once a list of models is loaded it sets up a select box to choose one and a `<wc-gocam-viz>` element to display the selected one. If the query returns no models a "no data" message and a link to https://geneontology.cloud/home is displayed.