### PR TITLE
Removes JXON use for native DOMParser for Pubmed abstract parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8222,14 +8222,6 @@
       "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
       "dev": true
     },
-    "jxon": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/jxon/-/jxon-2.0.0-beta.5.tgz",
-      "integrity": "sha1-O2qUEE+YAe5oL9BWZF/1Rz2bND4=",
-      "requires": {
-        "xmldom": "^0.1.21"
-      }
-    },
     "kdbush": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "express": "4.16.3",
     "golr-conf": "0.0.3",
     "jquery": "3.3.1",
-    "jxon": "2.0.0-beta.5",
     "markdown": "0.5.0",
     "marked": "0.3.19",
     "minerva-requests": "0.0.15",


### PR DESCRIPTION
fixes #655 

First time touching this codebase so tried to keep changes as minimal as possible. Line indentation looks a bit off as it appears there was a previous mix of tabs and spaces on the older code. Didn't attempt to change that as it should be addressed in a larger formatting once over changeset if needed.

As for the changes I did make: JXON was having some difficulties with the returned titles and abstracts for certain articles as uncovered in the linked AmiGO issue. Replacing the out of date JXON library with the native DOMParser module provides more control over the return type formatting and does not break on instance of embedded html tags in the results as JXON was breaking.

Went the route here to use each node's `textContent` value instead of `innerHTML` values to provide default stripping of those html tags. If it is instead desired to maintain Pubmed's inconsistent use of <i/> tags then innerHTML can be called instead.

Didn't find tests related to this page and @kltm advised that getting this running locally is a bit daunting to leaving this in their capable hands for now.