### PR TITLE
managing golr and amigo dns records

### DIFF
--- a/provision/aws/main.tf
+++ b/provision/aws/main.tf
@@ -31,14 +31,40 @@ variable "ami" {
   default = "ami-019eb5c97ad39d701"
 }
 
+// optional will be created if value is not an menty string
+variable "dns_record_name" {
+  type = list(string)
+  description = "type A DNS records wich will be mapped to public ip"
+  default = []
+}
+
+variable "dns_zone_id" {
+  type = string
+  description = "zone id for dns record."
+  default = ""
+}
+
+variable "use_elastic_ip" {
+  type = bool
+  description = "whether to use an elastic ip or not"
+  default = true
+}
+
 module "base" {
-  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V2.0"
+  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V3.1"
   instance_type = var.instance_type
   ami = var.ami
   public_key_path = var.public_key_path
+  dns_record_name = var.dns_record_name
+  dns_zone_id = var.dns_zone_id
+  use_elastic_ip = var.use_elastic_ip
   tags = var.tags
   open_ports = var.open_ports
   disk_size = var.disk_size
+}
+
+output "dns_records" {
+  value = module.base.dns_records
 }
 
 output "public_ip" {

--- a/provision/production/config-instance.yaml.sample
+++ b/provision/production/config-instance.yaml.sample
@@ -6,6 +6,11 @@ instance:
     tags:
        Name: REPLACE_ME  # This will be the tag used in AWS 
     instance_type: t2.large
+    use_elastic_ip: True
+
+    # LIST OF DNS type A records to create.
+    dns_record_name: [ "REPLACE_ME_FQDN_FOR_AMIGO", "REPLACE_ME_FQDN_FOR_GOLR" ]
+    dns_zone_id: "REPLACE_ME_FOR_DNS_ZONE_ID"
     disk_size: 200
     open_ports:
        - 80

--- a/provision/production/config-stack.yaml.sample
+++ b/provision/production/config-stack.yaml.sample
@@ -7,7 +7,7 @@ stack:
       PROD_MODE: 1
       stage_dir: /home/ubuntu/stage_dir
       amigo_image: geneontology/amigo-base:V1
-      apache_proxy_image: geneontology/apache-proxy:v4
+      apache_proxy_image: geneontology/apache-proxy:v6
       S3_CRED_FILE: /tmp/go-aws-credentials
 
       S3_BUCKET: REPLACE_ME_APACHE_LOG_BUCKET
@@ -32,9 +32,13 @@ stack:
       release_archive_doi: http://current.geneontology.org/metadata/release-archive-doi.json
 
 
-      AMIGO_DYNAMIC: REPLACE_ME            # aes-test-amigo.geneontology.io
-      AMIGO_DYNAMIC_ALIAS: REPLACE_ME      # aes-test-amigo.geneontology.io
-      AMIGO_PUBLIC_GOLR: REPLACE_ME        # aes-test-golr.geneontology.io
-      AMIGO_PUBLIC_GOLR_ALIAS: REPLACE_ME  # aes-test-golr.geneontology.io
+      AMIGO_DYNAMIC: REPLACE_ME            # This should be managed by terraform
+      AMIGO_DYNAMIC_ALIAS: REPLACE_ME      # This should point to final fqdn
+      AMIGO_PUBLIC_GOLR: REPLACE_ME        # This should be managed by terraform
+      AMIGO_PUBLIC_GOLR_ALIAS: REPLACE_ME  # This should point to final fqdn
       AMIGO_PUBLIC_GOLR_BULK: REPLACE_ME   # aes-test-golr.geneontology.io
+
+      # Populate with url for go api if desired. 
+      GO_API_URL: ""
+      USE_CLOUDFLARE: 0
    scripts: [ "stage.yaml", "start_services.yaml" ]

--- a/provision/stage.yaml
+++ b/provision/stage.yaml
@@ -190,7 +190,7 @@
       src: "files/robots.txt"
       dest: "{{ stage_dir }}/robots.txt"
 
-  - name: Check if index archive exists
+  - name: Check if repo exists
     stat:
       path: '{{ repo_dir }}'
     register: repo_dir_result

--- a/provision/templates/amigo-ssl.yaml
+++ b/provision/templates/amigo-ssl.yaml
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: 'Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.'
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: '{{ GO_API_URL }}'
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/provision/templates/amigo.yaml
+++ b/provision/templates/amigo.yaml
@@ -109,6 +109,10 @@ AMIGO_WORKING_PATH:
   comment: 'Please enter the full path to readable/writable directory that will be used for things like temporary files, logs (if enabled), and the golr_timestamp.log file.'
   type: directory
   value: /tmp
+GO_API_URL:
+  comment: Base URL of the GO API
+  type: url
+  value: '{{ GO_API_URL }}' 
 GOLR_CATALOG_LOCATION:
   comment: The location of the GO catalog file for various work.
   type: file

--- a/provision/templates/docker-compose-production.yaml
+++ b/provision/templates/docker-compose-production.yaml
@@ -8,6 +8,7 @@ services:
     environment:
       - GOLR=1
       - AMIGO=0
+      - GOLR_SOLR_MEMORY={{ GOLR_SOLR_MEMORY }}
     volumes:
       - {{ stage_dir }}/golr-configs/java-golr-monit:/etc/monit/conf-enabled/java
       - {{ stage_dir }}/golr-configs/console-capture-golr.xml:/etc/jetty9/console-capture.xml
@@ -38,11 +39,13 @@ services:
       - {{ stage_dir }}/amigo-configs/apache2.ports.conf:/etc/apache2/ports.conf
       - {{ stage_dir }}/apache_amigo_logs:/var/log/apache2
     restart: unless-stopped
-    healthcheck:
-       test: wget --no-verbose --timeout=5 --tries=5 --spider http://amigo:9999 || kill 1
-       interval: 60s
-       retries: 1
-       start_period: 30s
+    # Needs investigation: The server starts after a fresh install in about 90 seconds. But somehow it gets killed 
+    # after 60 seconds even though we set the start period to 300 seconds.
+    # healthcheck:
+    #   test: wget --no-verbose --timeout=5 --tries=5 --spider http://amigo:9999 || kill 1
+    #   interval: 60s
+    #   retries: 1
+    #   start_period: 300s
     depends_on:
       - golr 
 
@@ -58,6 +61,7 @@ services:
       - S3_BUCKET={{ S3_BUCKET }}
       - USE_SSL={{ USE_SSL }}
       - S3_SSL_CERTS_LOCATION={{ S3_SSL_CERTS_LOCATION }}
+      - USE_CLOUDFLARE={{ USE_CLOUDFLARE }}
     volumes:
       - {{ stage_dir }}/proxy-configs:/etc/apache2/sites-enabled
       - {{ stage_dir }}/apache_proxy_logs:/var/log/apache2

--- a/provision/vars.yaml
+++ b/provision/vars.yaml
@@ -36,6 +36,9 @@ GOLR_INPUT_ONTOLOGIES: "http://skyhook.berkeleybop.org/release/ontology/extensio
 GOLR_INPUT_GAFS: "http://current.geneontology.org/annotations/aspgd.gaf.gz
                  http://skyhook.berkeleybop.org/release/annotations/cgd.gaf.gz"
                   
+####
+#
+GO_API_URL: ""
 ########
 # For logrotate to s3 bucket
 #######`
@@ -62,3 +65,6 @@ AMIGO_DYNAMIC_ALIAS: amigo.example.com
 AMIGO_PUBLIC_GOLR: amigo-golr.example.com
 AMIGO_PUBLIC_GOLR_ALIAS: amigo-golr.example.com
 AMIGO_PUBLIC_GOLR_BULK: '{{ AMIGO_PUBLIC_GOLR }}'
+
+##
+USE_CLOUDFLARE: 0


### PR DESCRIPTION
- Pointing to latest `devops-aws-go-instance` which supports the managment of dns records
- Tested with latest python  `go-deploy` tool. (`devops-deployment-scripts`) The tool now supports:
  -show
  -output
  -destroy
