### PR TITLE
Update pantherdb enrichment form URLs to HTTPS

### DIFF
--- a/conf/rte_resources.yaml
+++ b/conf/rte_resources.yaml
@@ -4,6 +4,6 @@
 - id: PANTHER
   label: PANTHER
   description: ""
-  website: http://pantherdb.org
-  webservice: http://pantherdb.org/webservices/go/overrep.jsp
+  website: https://pantherdb.org
+  webservice: https://pantherdb.org/webservices/go/overrep.jsp
   logo: logo_panther.jpg

--- a/perl/lib/AmiGO/WebApp.pm
+++ b/perl/lib/AmiGO/WebApp.pm
@@ -953,7 +953,7 @@ sub _common_params_settings {
   $params->{interlink_rte} =
     #$self->{CORE}->get_interlink({mode=>'rte'});
     ## Temporary fix for: https://github.com/geneontology/amigo/issues/198
-    'http://pantherdb.org/webservices/go/overrep.jsp';
+    'https://pantherdb.org/webservices/go/overrep.jsp';
   ## Since there is no default search page, arrange for one.
   # my $def_search = $self->{CORE}->get_amigo_search_default();
   # $params->{interlink_search_default} =

--- a/templates/html/bs3/pages/landing.tmpl
+++ b/templates/html/bs3/pages/landing.tmpl
@@ -270,7 +270,7 @@
 	  <p>
 	    <!-- <small><a href="[% interlink_rte %]">Advanced options</a></small> -->
 	    <!-- <br /> -->
-	    <small>Powered by <a href="http://pantherdb.org">PANTHER</a></small>
+	    <small>Powered by <a href="https://pantherdb.org">PANTHER</a></small>
 	  </p>
 
 	  <!-- Allow user to make other choices in RTE. -->


### PR DESCRIPTION
For geneontology/helpdesk#455.

Searching the codebase for all instances of "http://pantherdb.org", I also found [WebApp.pm](https://github.com/geneontology/amigo/blob/8fad36622ea66fb21e544490cdc29e2b1af18c24/perl/lib/AmiGO/WebApp.pm#L956), which has a `param` key "interlink_rte". This is the same variable named in the [landing.tmpl](https://github.com/geneontology/amigo/blob/8fad36622ea66fb21e544490cdc29e2b1af18c24/templates/html/bs3/pages/landing.tmpl#L114) form so I think I'd have to change this in `WebApp.pm` as well.