### PR TITLE
Change PANTHER enrichment correction param to match GO site

### DIFF
--- a/templates/html/bs3/pages/landing.tmpl
+++ b/templates/html/bs3/pages/landing.tmpl
@@ -113,7 +113,7 @@
 	  <p>
 	    <form action="[% interlink_rte %]"
 		  class="" role="form" method="POST">
-	      <input type="hidden" name="correction" value="bonferroni" />
+	      <input type="hidden" name="correction" value="fdr" />
 	      <!-- <input type="hidden" name="format" value="xml" /> -->
 	      <input type="hidden" name="format" value="html" />
 	      <input type="hidden" name="resource" value="PANTHER" />


### PR DESCRIPTION
In checking [differences](https://github.com/geneontology/helpdesk/issues/455#issuecomment-1738113011) in enrichment widget code between amiGO and geneontology.org we noticed the correction parameter sent to PANTHER was different, "bonferroni" (amigo) vs "fdr" (GO).

Changing this to "fdr" (False Discovery Rate) to match the GO site for consistency.